### PR TITLE
Add display none

### DIFF
--- a/src/css/spring/spring-toc.css
+++ b/src/css/spring/spring-toc.css
@@ -38,6 +38,7 @@ body.toc-left #doc {
 
 #toc ul,
 #toc ol {
+  display: none;
   padding: 0;
 }
 


### PR DESCRIPTION
The layout have another TOC in left side, so I think we should add `display: none;`

![Ảnh chụp màn hình 2025-03-21 224225](https://github.com/user-attachments/assets/422242ba-5df8-4a1a-9ddd-b5c3c76b6733)

Reference
https://projectreactor.io/docs/core/release/reference/advancedFeatures/context.html